### PR TITLE
Fix HEX to RGB color in UIColor+Additions method

### DIFF
--- a/MobileRTCSample/MobileRTCSample/UIColor+Additions.m
+++ b/MobileRTCSample/MobileRTCSample/UIColor+Additions.m
@@ -12,9 +12,9 @@
 
 + (UIColor*)colorWithHex:(NSUInteger)hexColor
 {
-    CGFloat red = ((CGFloat)(hexColor & 0xFF0000)) / 255.f;
-    CGFloat green = ((CGFloat)(hexColor & 0xFF00)) / 255.f;
-    CGFloat blue = ((CGFloat)(hexColor & 0xFF)) / 255.f;
+    CGFloat red = ((hexColor >> 16) & 0xFF) / 255.f;
+    CGFloat green = ((hexColor >> 8) & 0xFF) / 255.f;
+    CGFloat blue = (hexColor & 0xFF) / 255.f;
     
     return [UIColor colorWithRed:red green:green blue:blue alpha:1.f];
 }


### PR DESCRIPTION
The `hexColor` must be shifted before the bitwise-AND with 0xFF mask so it gets the correct channel and doesn't overflow when it happens to be a big number for whatever reason.

The problem it's currently causing is described here:
https://devforum.zoom.us/t/change-colors-in-the-default-sdk-views